### PR TITLE
Closes #37: Replace node-config with a JS config file

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  endpoint: process.env.NODE_ENV === "production" ?
+    "https://tiles.services.mozilla.com/v3/links/ping-centre" :
+    "https://onyx_tiles.stage.mozaws.net/v3/links/ping-centre"
+};

--- a/config/default.json
+++ b/config/default.json
@@ -1,3 +1,0 @@
-{
-    "endpoint": "https://onyx_tiles.stage.mozaws.net/v3/links/ping-centre"
-}

--- a/config/production.json
+++ b/config/production.json
@@ -1,3 +1,0 @@
-{
-    "endpoint": "https://tiles.services.mozilla.com/v3/links/ping-centre"
-}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "homepage": "https://github.com/mozilla/ping-centre#readme",
   "dependencies": {
     "chai-as-promised": "^6.0.0",
-    "config": "^1.24.0",
     "isomorphic-fetch": "^2.2.1",
     "joi": "^10.0.1",
     "node-fetch": "^1.6.3",

--- a/ping-centre.js
+++ b/ping-centre.js
@@ -4,7 +4,7 @@ require("isomorphic-fetch");
 const commonSchema = require("./schemas/commonSchema");
 const Joi = require("joi");
 const uuid = require("uuid");
-const config = require("config");
+const config = require("./config");
 
 class PingCentre {
   constructor(topic, clientID, pingEndpoint) {
@@ -13,7 +13,7 @@ class PingCentre {
     }
     this._topic = topic;
     this._clientID = clientID || uuid();
-    this._pingEndpoint = pingEndpoint || config.get("endpoint");
+    this._pingEndpoint = pingEndpoint || config.endpoint;
 
     const schema = require(`./schemas/${topic}`);
     this._schema = schema || commonSchema;

--- a/test/endpoints.js
+++ b/test/endpoints.js
@@ -15,7 +15,7 @@ describe("Ping Centre Endpoints", function() {
     // required again in order to require config again and look up the
     // newly set environment variables.
     delete require.cache[require.resolve("../ping-centre")];
-    delete require.cache[require.resolve("config")];
+    delete require.cache[require.resolve("../config")];
 
     process.env["NODE_ENV"] = "production";
     const PingCentre = require("../ping-centre");


### PR DESCRIPTION
@emtwo Curious what you think of this alternative approach to loading prod vs. staging configs :-)

This is one possible solution to the problem of `node-config` breaking transpilers with its conditional dependencies (lorenwest/node-config#345).